### PR TITLE
Fix icon references

### DIFF
--- a/src/org/gark87/idea/javacc/JavaCCFileType.java
+++ b/src/org/gark87/idea/javacc/JavaCCFileType.java
@@ -6,6 +6,7 @@ import com.intellij.openapi.fileTypes.SyntaxHighlighter;
 import com.intellij.openapi.fileTypes.SyntaxHighlighterFactory;
 import com.intellij.openapi.util.IconLoader;
 import org.gark87.idea.javacc.generated.JavaCCLanguage;
+import org.gark87.idea.javacc.util.JavaCCIcons;
 import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
@@ -14,7 +15,6 @@ import javax.swing.*;
  * @author gark87
  */
 public class JavaCCFileType extends LanguageFileType {
-    public static final Icon FILE = IconLoader.findIcon("/javacc/icons/javacc.png");
 
     public JavaCCFileType() {
         super(new JavaCCLanguage());
@@ -46,6 +46,6 @@ public class JavaCCFileType extends LanguageFileType {
 
     @Override
     public Icon getIcon() {
-        return FILE;
+        return JavaCCIcons.JAVACC_FILE.getIcon();
     }
 }

--- a/src/org/gark87/idea/javacc/JavaCCStructureViewBuilderFactory.java
+++ b/src/org/gark87/idea/javacc/JavaCCStructureViewBuilderFactory.java
@@ -89,11 +89,9 @@ public class JavaCCStructureViewBuilderFactory implements PsiStructureViewFactor
     }
 
     private static class JavaCCLeafElement extends PsiTreeElementBase<Identifier> {
-        private final Icon icon;
 
         protected JavaCCLeafElement(DeclarationForStructureView declaration) {
             super(declaration.getIdentifier());
-            icon = declaration.getIcon();
         }
 
         @NotNull
@@ -108,11 +106,6 @@ public class JavaCCStructureViewBuilderFactory implements PsiStructureViewFactor
             if (element == null)
                 return "";
             return element.getName();
-        }
-
-        @Override
-        public Icon getIcon(boolean open) {
-            return icon;
         }
     }
 }

--- a/src/org/gark87/idea/javacc/psi/BNFProduction.java
+++ b/src/org/gark87/idea/javacc/psi/BNFProduction.java
@@ -5,11 +5,13 @@ import com.intellij.openapi.util.IconLoader;
 
 import javax.swing.*;
 
+import org.gark87.idea.javacc.util.JavaCCIcons;
+
+
 /**
  * @author gark87
  */
 public class BNFProduction extends NonTerminalProduction {
-    private static Icon ICON;
 
     public BNFProduction(@org.jetbrains.annotations.NotNull ASTNode node) {
         super(node);
@@ -22,8 +24,6 @@ public class BNFProduction extends NonTerminalProduction {
 
     @Override
     public Icon getIcon() {
-        if (ICON == null)
-            ICON = IconLoader.getIcon("/javacc/icons/nonterminal.png");
-        return ICON;
+        return JavaCCIcons.NONTERMINAL.getIcon();
     }
 }

--- a/src/org/gark87/idea/javacc/psi/RegExpSpec.java
+++ b/src/org/gark87/idea/javacc/psi/RegExpSpec.java
@@ -4,6 +4,7 @@ import com.intellij.lang.ASTNode;
 import com.intellij.openapi.util.IconLoader;
 import com.intellij.psi.PsiElement;
 import org.gark87.idea.javacc.generated.JavaCCTreeConstants;
+import org.gark87.idea.javacc.util.JavaCCIcons;
 
 import javax.swing.*;
 
@@ -11,7 +12,6 @@ import javax.swing.*;
 * @author gark87
 */
 public class RegExpSpec extends JavaCCStub implements DeclarationForStructureView {
-    private static Icon ICON;
 
     public RegExpSpec(@org.jetbrains.annotations.NotNull ASTNode node) {
         super(node);
@@ -35,8 +35,6 @@ public class RegExpSpec extends JavaCCStub implements DeclarationForStructureVie
 
     @Override
     public Icon getIcon() {
-        if (ICON == null)
-            ICON = IconLoader.getIcon("/javacc/icons/terminal.png");
-        return ICON;
+        return JavaCCIcons.TERMINAL.getIcon();
     }
 }

--- a/src/org/gark87/idea/javacc/util/JavaCCIcons.java
+++ b/src/org/gark87/idea/javacc/util/JavaCCIcons.java
@@ -1,0 +1,31 @@
+package org.gark87.idea.javacc.util;
+
+import javax.swing.Icon;
+
+import com.intellij.openapi.util.IconLoader;
+
+
+/**
+ * Interfaces with the icons of the plugin.
+ */
+public enum JavaCCIcons {
+    /** Terminal icon for the structure view. */
+    TERMINAL("terminal.png"),
+    /** Non-terminal icon for the structure view. */
+    NONTERMINAL("nonterminal.png"),
+    /** File type icon. */
+    JAVACC_FILE("javacc.png");
+
+    private final Icon icon;
+
+
+    JavaCCIcons(String fname) {
+        icon = IconLoader.getIcon("icons/" + fname);
+    }
+
+
+    /** Returns the AWT icon. */
+    public Icon getIcon() {
+        return icon;
+    }
+}


### PR DESCRIPTION
The icon paths shouldn't mention the "javacc" segment. This caused the icons to not be resolved, throwing an exception that prevents the structure view to be populated with the structure.